### PR TITLE
Support timestamp from environment

### DIFF
--- a/bookman
+++ b/bookman
@@ -45,6 +45,9 @@ OPTIONS
   -c coverfile	Uses the file coverfile to generate the cover page,
 		i.e. all pages preceding the table of content. coverfile
 		must be in groff_ms(7) format.
+ENVIRONMENT
+  SOURCE_DATE_EPOCH  Unix timestamp that is used for date in header instead
+                     of current date.
 
 EXAMPLE
   To build a reference manual from section 2 man, do:
@@ -81,6 +84,9 @@ do
 	esac
 done
 shift $(($OPTIND - 1))
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+  date=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
+fi
 date=${date:-$(date +'%d %B %Y')}
 
 [[ $1 ]] || set -- $(while read; do echo $REPLY; done)

--- a/bookman.1
+++ b/bookman.1
@@ -62,6 +62,11 @@ Specify the name of the \fIvolume\fP.
 Uses the file \fIcoverfile\fP to generate the cover page,
 i.e. all pages preceding the table of content. \fIcoverfile\fP
 must be in \fBgroff_ms\fP(7) format.
+.SH ENVIRONMENT
+.TP
+.B
+SOURCE_DATE_EPOCH
+Unix timestamp that is used for date in header instead of current date.
 .SH EXAMPLE
 To build a reference manual from section 2 man, do:
 .PP

--- a/src2man
+++ b/src2man
@@ -58,6 +58,9 @@ OPTIONS
   		of generated manpages.
   -r release	Specify the project name and release number for the generated
 		manpage.
+ENVIRONMENT
+  SOURCE_DATE_EPOCH  Unix timestamp that is used for date in header instead
+                     of current date.
 EXAMPLE
   The following example displays C code and comments to generate a manpage
   foobar.3:
@@ -94,6 +97,9 @@ do
 	esac
 done
 shift $(($OPTIND - 1))
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+  date=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
+fi
 date=${date:-$(date +'%d %B %Y')}
 
 #

--- a/src2man.1
+++ b/src2man.1
@@ -53,6 +53,11 @@ of generated manpages.
 \fB-r\fP \fIrelease\fP
 Specify the project name and \fIrelease\fP number for the generated
 manpage.
+.SH ENVIRONMENT
+.TP
+.B
+SOURCE_DATE_EPOCH
+Unix timestamp that is used for date in header instead of current date.
 .SH EXAMPLE
 The following example displays C code and comments to generate a manpage
 foobar.3:

--- a/txt2man
+++ b/txt2man
@@ -96,8 +96,10 @@ OPTIONS
   -T          Text result previewing using PAGER, usually more(1).
   -X          X11 result previewing using gxditview(1).
 ENVIRONMENT
-  PAGER    name of paging command, usually more(1), or less(1). If not set
-           falls back to more(1).
+  PAGER              name of paging command, usually more(1), or less(1). If not set
+                     falls back to more(1).
+  SOURCE_DATE_EPOCH  Unix timestamp that is used for date in header instead
+                     of current date.
 EXAMPLE
   Try this command to format this text itself:
 
@@ -146,6 +148,9 @@ do
 	esac
 done
 shift $(($OPTIND - 1))
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+  date=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
+fi
 date=${date:-$(date +'%d %B %Y')}
 
 if test "$doprobe"

--- a/txt2man.1
+++ b/txt2man.1
@@ -143,6 +143,10 @@ X11 result previewing using \fBgxditview\fP(1).
 PAGER
 name of paging command, usually \fBmore\fP(1), or \fBless\fP(1). If not set
 falls back to \fBmore\fP(1).
+.TP
+.B
+SOURCE_DATE_EPOCH
+Unix timestamp that is used for date in header instead of current date.
 .SH EXAMPLE
 Try this command to format this text itself:
 .PP


### PR DESCRIPTION
To enable reproducible builds, a Unix timestamp set in the environment
variable SOURCE_DATE_EPOCH is used as the default instead of the
current date, if it is set.

See also: https://reproducible-builds.org/specs/source-date-epoch/
