### PR TITLE
Use share/ directory for manpages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ MAN1 = src2man.1 txt2man.1 bookman.1
 all: $(MAN1)
 
 install: $(MAN1)
-	mkdir -p $(prefix)/bin $(prefix)/man/man1
+	mkdir -p $(prefix)/bin $(prefix)/share/man/man1
 	cp $(BIN) $(prefix)/bin/
-	cp $(MAN1) $(prefix)/man/man1
+	cp $(MAN1) $(prefix)/share/man/man1
 
 clean:
 	rm -f *.1 *.txt *.ps *.pdf *.html


### PR DESCRIPTION
Hi,

I am the current txt2man maintainer in Debian. I will try to help with some issues found. The first is here.

The /usr/local/ has the man/ object which is a symlink to /usr/local/share/man. However, if the 'prefix' is changed to /usr, the man pages will be installed at a wrong path. So, is preferable to use $(prefix)/share/man/man1 instead of $(prefix)/man/man1. It will make easier the packaging in several distros.

Thanks in advance.

Regards,

Eriberto
