### PR TITLE
Fix some spelling errors and improve the manpage

### DIFF
--- a/txt2man
+++ b/txt2man
@@ -45,26 +45,32 @@ DESCRIPTION
   Here is how text patterns are recognized and processed:
   Sections    These headers are defined by a line in upper case, starting
               column 1. If there is one or more leading spaces, a
-	      sub-section will be generated instead.
+              sub-section will be generated instead. Optionally, the
+              Section name can be preceded by a blank line. This is useful
+              for a better visualization of the source text to be used to
+              generate the manpage.
   Paragraphs  They must be separated by a blank line, and left aligned.
+              Alternatively two blank spaces can be used to produce the
+              same result. This option will provide a better visualization
+              of the source text to be used to generate the manpage.
   Tag list    The item definition is separated from the item description
               by at least 2 blank spaces, even before a new line, if
               definition is too long. Definition will be emphasized
               by default.
-  Bullet list  
+  Bullet list
               Bullet list items are defined by the first word being "-"
-	      or "*" or "o".
-  Enumerated list  
-	      The first word must be a number followed by a dot.
-  Literal display blocks  
-	      This paragraph type is used to display unmodified text,
-	      for example source code. It must be separated by a blank
-	      line, and be indented. It is primarily used to format
-	      unmodified source code. It will be printed using fixed font
-	      whenever possible (troff).
-  Cross references  
-	      A cross reference (another man page) is defined by a word
-	      followed by a number in parenthesis.
+              or "*" or "o".
+  Enumerated list
+              The first word must be a number followed by a dot.
+  Literal display blocks
+              This paragraph type is used to display unmodified text,
+              for example source code. It must be separated by a blank
+              line and be indented by a TAB. It is primarily used to format
+              unmodified source code. It will be printed using fixed font
+              whenever possible (troff).
+  Cross references
+              A cross reference (another man page) is defined by a word
+              followed by a number in parenthesis.
 
   Special sections:
   NAME      The function or command name and short description are set in
@@ -72,13 +78,13 @@ DESCRIPTION
   SYNOPSIS  This section receives a special treatment to identify command
             name, flags and arguments, and propagate corresponding
             attributes later in the text. If a C like function is recognized
-	    (word immediately followed by an open parenthesis), txt2man will
-	    print function name in bold font, types in normal font, and
-	    variables in italic font. The whole section will be printed using
-	    a fixed font family (courier) whenever possible (troff).
+            (word immediately followed by an open parenthesis), txt2man will
+            print function name in bold font, types in normal font, and
+            variables in italic font. The whole section will be printed using
+            a fixed font family (courier) whenever possible (troff).
 
   It is a good practice to embed documentation into source code, by using
-  comments or constant text variables. txt2man allows to do that, keeping
+  comments or constant text variables. txt2man allows one to do that, keeping
   the document source readable, usable even without further formatting
   (i.e. for online help) and easy to write. The result is high quality
   and standard complying document.
@@ -89,7 +95,7 @@ OPTIONS
   -p          Probe title, section name and volume.
   -t mytitle  Set mytitle as title of generated man page.
   -r rel      Set rel as project name and release.
-  -s sect     Set sect as section in heading, ususally a value from 1 to 8.
+  -s sect     Set sect as section in heading, usually a value from 1 to 8.
   -v vol      Set vol as volume name, i.e. "Unix user 's manual".
   -I txt      Italicize txt in output. Can be specified more than once.
   -B txt      Emphasize (bold) txt in output. Can be specified more than once.
@@ -100,12 +106,17 @@ ENVIRONMENT
                      falls back to more(1).
   SOURCE_DATE_EPOCH  Unix timestamp that is used for date in header instead
                      of current date.
-EXAMPLE
+EXAMPLES
   Try this command to format this text itself:
 
-      $ txt2man -h 2>&1 | txt2man -T
+    $ txt2man -h 2>&1 | txt2man -T
+
+  The following command will generate a manpage from txt2man.txt file, used
+  as source code:
+
+    $ txt2man -d "15 May 2016" -t txt2man -r 1.5.6 -s 1 -v "converts text to man page" txt2man.txt > txt2man.1
 HINTS
-  To obtain an overall good formating of output document, keep paragraphs
+  To obtain an overall good formatting of output document, keep paragraphs
   indented correctly. If you have unwanted bold sections, search for
   multiple spaces between words, which are used to identify a tag list
   (term followed by a description). Choose also carefully the name of

--- a/txt2man.1
+++ b/txt2man.1
@@ -116,7 +116,7 @@ Set \fIrel\fP as project name and release.
 .TP
 .B
 \fB-s\fP \fIsect\fP
-Set \fIsect\fP as section in heading, ususally a value from 1 to 8.
+Set \fIsect\fP as section in heading, usually a value from 1 to 8.
 .TP
 .B
 \fB-v\fP \fIvol\fP

--- a/txt2man.1
+++ b/txt2man.1
@@ -116,7 +116,7 @@ Set \fIrel\fP as project name and release.
 .TP
 .B
 \fB-s\fP \fIsect\fP
-Set \fIsect\fP as section in heading, usually a value from 1 to 8.
+Set \fIsect\fP as section in heading, ususally a value from 1 to 8.
 .TP
 .B
 \fB-v\fP \fIvol\fP


### PR DESCRIPTION
Hi,

This pull request add some operational details to manpage and fix the following spelling errors:

s/txt2man allows to do/txt2man allows one to do/
s/ususally/usually/
s/formating/formatting/

I did a revert to fix a little mistake of mine. Sorry.

Regards,

Eriberto
