### PR TITLE
remove redundant escapes causing gawk warnings

### DIFF
--- a/txt2man
+++ b/txt2man
@@ -242,7 +242,7 @@ BEGIN {
 		pnzls = ls
 	match($0, /[^ ]/)
 	ls = RSTART
-	if (pls == 0 && pnzls > 0 && ls > pnzls && $1 !~ /^[0-9\-\*\o]\.*$/) {
+	if (pls == 0 && pnzls > 0 && ls > pnzls && $1 !~ /^[0-9\-\*o]\.*$/) {
 		# example display block
 		if (prevblankline == 1) {
 			print ".PP"
@@ -300,7 +300,7 @@ section == "SYNOPSIS" {
 		} else if ($1 == "#define")
 			subwords["\\<" $2 "\\>"] = "\\fI" $2 "\\fP"
 		for (i = 1; i <= NF; i++) {
-			if ($i ~ /[\,\)]\;*$/) {
+			if ($i ~ /[,\)];*$/) {
 				a = $i
 				sub(/.*\(/, "", a)
 				gsub(/\W/, "", a)


### PR DESCRIPTION
I just learned about this program today and on trying it, I got the warnings:

```
gawk: cmd. line:58: warning: regexp escape sequence `\o' is not a known regexp operator
gawk: cmd. line:116: warning: regexp escape sequence `\,' is not a known regexp operator
gawk: cmd. line:116: warning: regexp escape sequence `\;' is not a known regexp operator
```

So, this commit removes the escapes.