### PR TITLE
Fix usage of the date command on BSD systems

### DIFF
--- a/bookman
+++ b/bookman
@@ -84,8 +84,16 @@ do
 	esac
 done
 shift $(($OPTIND - 1))
+
+# Compatibility wrapper for BSD/GNU date, for parsing dates
+if date -j >/dev/null 2>&1; then
+  pdate() { date -u -j -f '@%s' "$@"; }
+else
+  pdate() { date -u -d "$@"; }
+fi
+
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
-  date=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
+  date=$(LC_ALL=C pdate "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
 fi
 date=${date:-$(date +'%d %B %Y')}
 

--- a/bookman
+++ b/bookman
@@ -95,7 +95,7 @@ fi
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
   date=$(LC_ALL=C pdate "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
 fi
-date=${date:-$(date +'%d %B %Y')}
+date=${date:-$(LC_ALL=C date -u +'%d %B %Y')}
 
 [ $1 ] || set -- $(while read REPLY; do echo "$REPLY"; done)
 

--- a/src2man
+++ b/src2man
@@ -97,8 +97,16 @@ do
 	esac
 done
 shift $(($OPTIND - 1))
+
+# Compatibility wrapper for BSD/GNU date, for parsing dates
+if date -j >/dev/null 2>&1; then
+  pdate() { date -u -j -f '@%s' "$@"; }
+else
+  pdate() { date -u -d "$@"; }
+fi
+
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
-  date=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
+  date=$(LC_ALL=C pdate "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
 fi
 date=${date:-$(date +'%d %B %Y')}
 

--- a/src2man
+++ b/src2man
@@ -108,7 +108,7 @@ fi
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
   date=$(LC_ALL=C pdate "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
 fi
-date=${date:-$(date +'%d %B %Y')}
+date=${date:-$(LC_ALL=C date -u +'%d %B %Y')}
 
 #
 # Extract manpages from source files. Man page content is enclosed in

--- a/txt2man
+++ b/txt2man
@@ -170,7 +170,7 @@ fi
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
   date=$(LC_ALL=C pdate "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
 fi
-date=${date:-$(LC_ALL=C date +'%d %B %Y')}
+date=${date:-$(LC_ALL=C date -u +'%d %B %Y')}
 
 if test "$doprobe"
 then

--- a/txt2man
+++ b/txt2man
@@ -159,8 +159,16 @@ do
 	esac
 done
 shift $(($OPTIND - 1))
+
+# Compatibility wrapper for BSD/GNU date, for parsing dates
+if date -j >/dev/null 2>&1; then
+  pdate() { date -u -j -f '@%s' "$@"; }
+else
+  pdate() { date -u -d "$@"; }
+fi
+
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
-  date=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
+  date=$(LC_ALL=C pdate "@$SOURCE_DATE_EPOCH" +'%d %B %Y')
 fi
 date=${date:-$(LC_ALL=C date +'%d %B %Y')}
 


### PR DESCRIPTION
BSD and GNU implementations of the date command are slightly incompatible.

The GNU implementation can take an arbitrary date with the -d option, and
the format is automatically detected, but on BSD implementations it must
be invoked like for setting the system date but using the -j option to
avoid that step, and the input format must be provided with the -f option.

Since the -j option isn't supported by the GNU implementation, it can be
exploited to detect which variant the system uses.

Closes: https://github.com/mvertes/txt2man/issues/19

Signed-off-by: Ismael Luceno <ismael@iodev.co.uk>