### PR TITLE
Print names of manuals to stdout

### DIFF
--- a/src2man
+++ b/src2man
@@ -180,7 +180,7 @@ $1 == "/**" && $2 ~ /^[0-9]/ {
 			}
 		}
 	}
-	print title "." sect > "/dev/stderr"
+	print title "." sect > "/dev/stdout"
 	if (nogen) {
 		name = synop = desc = sect = ""
 		next


### PR DESCRIPTION
Print names of manuals to stdout instead of stderr,
because they are often mixed up with gawk's warning messages,
which are also printed out to stderr:

```
gawk: manual.3cmd. line:58:
warning: regexp escape sequence `\o' is not a known regexp operator
```

instead of:

```
gawk: cmd. line:58: warning: regexp escape sequence `\o' is not a known regexp operator
manual.3
```

Fixes: #23