### PR TITLE
Make src2man compliant with gawk >= 5.0.1

### DIFF
--- a/src2man
+++ b/src2man
@@ -177,12 +177,12 @@ $1 == "/**" && $2 ~ /^[0-9]/ {
 				getline
 				synop = synop " " $0
 			}
-			if ($0 ~/\)[ \t{}\;]*$/) {
+			if ($0 ~/\)[ \t{};]*$/) {
 				sub(/{[^}]}/, "", synop)
 				sub(/[ \t]*$/, "", synop)
 				if (found == "ok")
 					synop = "#include \"" inc "\"\n" synop
-				if (synop !~ /\;$/)
+				if (synop !~ /;$/)
 					synop = synop ";"
 				break
 			}


### PR DESCRIPTION
These changes avoid:

awk: cmd. line:64: warning: regexp escape sequence `\;' is not a known regexp operator