### PR TITLE
Add checks for dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Makefile
 prefix ?= /usr/local
 version = txt2man-1.7.0
+date = 2020-06-03
 BIN = src2man bookman txt2man
 MAN1 = src2man.1 txt2man.1 bookman.1
 
@@ -14,7 +15,7 @@ install: $(MAN1)
 clean:
 	rm -f *.1 *.txt *.ps *.pdf *.html
 
-%.1:%.txt; ./txt2man -s 1 -t $* -r $(version) $< > $@
+%.1:%.txt; ./txt2man -s 1 -t $* -r $(version) -d $(date) $< > $@
 %.txt:%; ./$< -h 2>&1 > $@
 %.html:%.1; rman -f HTML $< > $@
 %.ps:%.1; groff -man $< > $@

--- a/bookman
+++ b/bookman
@@ -91,7 +91,7 @@ shift $(($OPTIND - 1))
 			exit 1
 			}
 
-{ ps2pdf 2>&1 | grep Usage ; } > /dev/null 2> /dev/null || {
+ps2pdf 2>&1 | grep -q Usage || {
 			printf "ERROR: You need install ghostscript.\n" >&2
 			exit 1
 			}

--- a/bookman
+++ b/bookman
@@ -86,7 +86,7 @@ done
 shift $(($OPTIND - 1))
 
 # Check for dependencies
-{ echo ok | groff -ms ; } > /dev/null 2> /dev/null || {
+ groff -ms /dev/null || {
 			printf "ERROR: You need install groff.\n" >&2
 			exit 1
 			}

--- a/bookman
+++ b/bookman
@@ -85,6 +85,17 @@ do
 done
 shift $(($OPTIND - 1))
 
+# Check for dependencies
+{ echo ok | groff -ms ; } > /dev/null 2> /dev/null || {
+			printf "ERROR: You need install groff.\n" >&2
+			exit 1
+			}
+
+{ ps2pdf 2>&1 | grep Usage ; } > /dev/null 2> /dev/null || {
+			printf "ERROR: You need install ghostscript.\n" >&2
+			exit 1
+			}
+
 # Compatibility wrapper for BSD/GNU date, for parsing dates
 if date -j >/dev/null 2>&1; then
   pdate() { date -u -j -f '@%s' "$@"; }


### PR DESCRIPTION
bookman command depends of groff and ghostscript. However, the in absence
of these dependencies, no intuitive messages are shown to final users. This
commit adds checks for groff and ghostscript presence and show specific
messages to users.

Closes #27 